### PR TITLE
Example of slow performance with a large object when immer creates multiple drafts internally

### DIFF
--- a/__performance_tests__/multiple-drafts.js
+++ b/__performance_tests__/multiple-drafts.js
@@ -1,0 +1,47 @@
+"use strict"
+
+import {measure} from "./measure"
+import produce, {
+	setAutoFreeze,
+	setUseProxies,
+	enableAllPlugins
+} from "../dist/immer.cjs.production.min.js"
+import cloneDeep from "lodash.clonedeep"
+import {fromJS} from "immutable"
+import Seamless from "seamless-immutable"
+import deepFreeze from "deep-freeze"
+
+enableAllPlugins()
+
+console.log(
+	"\n# multiple-drafts - loading large set of data and updating a Set\n"
+)
+
+const dataSet = require("./data.json")
+const baseState = {
+	data: null,
+	data2: new Set()
+}
+const frozenBazeState = deepFreeze(cloneDeep(baseState))
+
+const MAX = 1000
+
+measure("immer (proxy) - without autofreeze * " + MAX, () => {
+	setUseProxies(true)
+	setAutoFreeze(false)
+	for (let i = 0; i < MAX; i++)
+		produce(baseState, draft => {
+			draft.data = dataSet
+			draft.data2.add(1)
+		})
+})
+
+measure("immer (proxy) - with autofreeze * " + MAX, () => {
+	setUseProxies(true)
+	setAutoFreeze(true)
+	for (let i = 0; i < MAX; i++)
+		produce(frozenBazeState, draft => {
+			draft.data = dataSet
+			draft.data2.add(1)
+		})
+})

--- a/__performance_tests__/multiple-drafts.js
+++ b/__performance_tests__/multiple-drafts.js
@@ -45,3 +45,23 @@ measure("immer (proxy) - with autofreeze * " + MAX, () => {
 			draft.data2.add(1)
 		})
 })
+
+measure("immer (es5) - without autofreeze * " + MAX, () => {
+	setUseProxies(false)
+	setAutoFreeze(false)
+	for (let i = 0; i < MAX; i++)
+		produce(baseState, draft => {
+			draft.data = dataSet
+			draft.data2.add(1)
+		})
+})
+
+measure("immer (es5) - with autofreeze * " + MAX, () => {
+	setUseProxies(false)
+	setAutoFreeze(true)
+	for (let i = 0; i < MAX; i++)
+		produce(frozenBazeState, draft => {
+			draft.data = dataSet
+			draft.data2.add(1)
+		})
+})


### PR DESCRIPTION
```
$ yarn run babel-node __performance_tests__/multiple-drafts.js

# multiple-drafts - loading large set of data and updating a Set

immer (proxy) - without autofreeze * 1000: 6977ms
immer (proxy) - with autofreeze * 1000: 32ms
immer (es5) - without autofreeze * 1000: 35ms
immer (es5) - with autofreeze * 1000: 43ms
```

This optimization doesn't get used when there are multiple drafts in the Immer object: https://github.com/immerjs/immer/blob/master/src/core/finalize.ts#L142 - mutating a `Set` in the state creates a new draft.